### PR TITLE
Also check for the Contao mono repository package

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -76,7 +76,11 @@ class Plugin implements BundlePluginInterface
      */
     protected function getContaoCoreVersion(): string
     {
-        return Versions::getVersion('contao/core-bundle');
+        try {
+            return Versions::getVersion('contao/core-bundle');
+        } catch (\OutOfBoundsException $e) {
+            return Versions::getVersion('contao/contao');
+        }
     }
 
     /**


### PR DESCRIPTION
If you use the `contao/contao` mono repository (instead of the individual bundles) for PR purposes and install this package (or a Contao extension that requires this package), then the following error will occur:

```
Script Contao\ManagerBundle\Composer\ScriptHandler::initializeApplication handling the post-install-cmd event terminated with an exception


  [RuntimeException]
  An error occurred while executing the "contao:install-web-dir" command:                                                                                                                                              
  In Versions.php line 297:

    [OutOfBoundsException]
    Required package "contao/core-bundle" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files  

                                                                                                                                                                                                                       
  Exception trace:
    at Cvendor\composer\package-versions-deprecated\src\PackageVersions\Versions.php:297
   PackageVersions\Versions::getVersion() at Cvendor\contao-community-alliance\contao-polyfill-bundle\src\ContaoManager\Plugin.php:79
   ContaoCommunityAlliance\Polyfills\ContaoManager\Plugin->getContaoCoreVersion() at Cvendor\contao-community-alliance\contao-polyfill-bundle\src\ContaoManager\Plugin.php:46  
   ContaoCommunityAlliance\Polyfills\ContaoManager\Plugin->getBundles() at Cvendor\contao\manager-plugin\src\Bundle\BundleLoader.php:98
   Contao\ManagerPlugin\Bundle\BundleLoader->loadFromPlugins() at Cvendor\contao\manager-plugin\src\Bundle\BundleLoader.php:79
   Contao\ManagerPlugin\Bundle\BundleLoader->loadFromCache() at Cvendor\contao\manager-plugin\src\Bundle\BundleLoader.php:63
   Contao\ManagerPlugin\Bundle\BundleLoader->getBundleConfigs() at Cvendor\contao\contao\manager-bundle\src\HttpKernel\ContaoKernel.php:355
   Contao\ManagerBundle\HttpKernel\ContaoKernel->addBundlesFromPlugins() at Cvendor\contao\contao\manager-bundle\src\HttpKernel\ContaoKernel.php:74
   Contao\ManagerBundle\HttpKernel\ContaoKernel->registerBundles() at Cvendor\symfony\http-kernel\Kernel.php:446
   Symfony\Component\HttpKernel\Kernel->initializeBundles() at Cvendor\symfony\http-kernel\Kernel.php:133
   Symfony\Component\HttpKernel\Kernel->boot() at Cvendor\symfony\framework-bundle\Console\Application.php:169
   Symfony\Bundle\FrameworkBundle\Console\Application->registerCommands() at Cvendor\symfony\framework-bundle\Console\Application.php:75
   Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at Cvendor\symfony\console\Application.php:149
   Symfony\Component\Console\Application->run() at Cvendor\contao\contao\manager-bundle\bin\contao-console:38
```

This PR catches the `OutOfBoundsException` and tries again with the mono repository.