### PR TITLE
Fix version detection

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -13,6 +13,7 @@
  * @package    contao-community-alliance/contao-polyfill-bundle
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2019-2021 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/contao-polyfill-bundle/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -45,7 +46,7 @@ class Plugin implements BundlePluginInterface
         $bundles     = [];
         $coreVersion = $this->getContaoCoreVersion();
         $loadAfter   = [ContaoCoreBundle::class];
-        if (0 === strncmp($coreVersion, 'dev-master', 10)) {
+        if (!\preg_match('/^(\d+\.)+\d+$/', $coreVersion)) {
             return [];
         }
 
@@ -76,7 +77,7 @@ class Plugin implements BundlePluginInterface
      */
     protected function getContaoCoreVersion(): string
     {
-        return PackageUtil::getVersion('contao/core-bundle');
+        return PackageUtil::getVersion('contao/core-bundle') ?: PackageUtil::getVersion('contao/contao');
     }
 
     /**

--- a/tests/ContaoManager/PluginTest.php
+++ b/tests/ContaoManager/PluginTest.php
@@ -13,6 +13,7 @@
  * @package    contao-community-alliance/contao-polyfill-bundle
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2019-2021 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/contao-polyfill-bundle/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -64,6 +65,10 @@ class PluginTest extends TestCase
                 CcaContaoPolyfill49Bundle::class
             ],
             'dev-master@012345678' => [
+            ],
+            '4.x@012345678' => [
+            ],
+            'dev-other-branch' => [
             ],
         ] as $version => $bundleClasses) {
             yield [


### PR DESCRIPTION
Currently, the polyfill bundle fails to detect the correct version
- if `contao/core-bundle` is not installed but `contao/contao` 
- if a custom branch is checked out
